### PR TITLE
Added add_chr argument to barplotAlleleFreqs method

### DIFF
--- a/R/barplotAlleleFreqs.R
+++ b/R/barplotAlleleFreqs.R
@@ -27,6 +27,7 @@ setGeneric("barplotAlleleFreqs", function(obj, ...) {
 #'@param include.chimeras Should chimeric reads be included in results?
 #'(Default: TRUE)
 #'@param palette  Colour palette.  Options are "rainbow", a quantitative palette
+#'@param add_chr Add "chr" to chromosome names to make compatible with UCSC (default: TRUE)
 #'(default) or "bluered", a gradient palette.
 #'@rdname barplotAlleleFreqs
 setMethod("barplotAlleleFreqs", signature("CrisprSet"),

--- a/R/barplotAlleleFreqs.R
+++ b/R/barplotAlleleFreqs.R
@@ -31,7 +31,7 @@ setGeneric("barplotAlleleFreqs", function(obj, ...) {
 #'@rdname barplotAlleleFreqs
 setMethod("barplotAlleleFreqs", signature("CrisprSet"),
   function(obj, ..., txdb, min.freq = 0, include.chimeras = TRUE, group = NULL,
-           palette = c("rainbow", "bluered")){
+           palette = c("rainbow", "bluered"), add_chr = TRUE){
 
     # Potential improvements:
     # Do filtering before variant location
@@ -60,7 +60,7 @@ setMethod("barplotAlleleFreqs", signature("CrisprSet"),
                     "inframe indel > 10",  "frameshift indel < 9",
                     expression("frameshift indel" >= 10))
     
-    var_type <- obj$classifyVariantsByLoc(txdb)
+    var_type <- obj$classifyVariantsByLoc(txdb, add_chr = add_chr)
     classification <- obj$classifyCodingBySize(var_type)
     classification["Other"] <- "Chimeric"
     


### PR DESCRIPTION
I noticed when working with a txdb object that did not have seqlevels with the 'chr' prefix that the `barplotAlleleFreqs` method always added it by default. Maybe passing through the `add_chr` argument would be useful?